### PR TITLE
Add login choice and API call

### DIFF
--- a/pretixscan/app/src/main/AndroidManifest.xml
+++ b/pretixscan/app/src/main/AndroidManifest.xml
@@ -72,6 +72,12 @@
             android:name=".ui.SetupActivity"
             android:label="@string/headline_setup" />
         <activity
+            android:name=".ui.ChooseModeActivity"
+            android:label="@string/app_name" />
+        <activity
+            android:name=".ui.LoginActivity"
+            android:label="@string/app_name" />
+        <activity
             android:name=".ui.info.EventinfoActivity"
             android:label="@string/action_label_statistics"
             android:parentActivityName=".ui.MainActivity" />

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/ChooseModeActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/ChooseModeActivity.kt
@@ -1,0 +1,34 @@
+package eu.pretix.pretixscan.droid.ui
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import eu.pretix.pretixscan.droid.R
+import eu.pretix.pretixscan.droid.databinding.ActivityChooseModeBinding
+
+class ChooseModeActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityChooseModeBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_choose_mode)
+
+        binding.btnNext.setOnClickListener {
+            when {
+                binding.cbSignIn.isChecked -> {
+                    startActivity(Intent(this, LoginActivity::class.java))
+                    finish()
+                }
+                binding.cbCheckIn.isChecked -> {
+                    startActivity(Intent(this, MainActivity::class.java))
+                    finish()
+                }
+                else -> {
+                    Toast.makeText(this, getString(R.string.error_no_option_selected), Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+}

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/LoginActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/LoginActivity.kt
@@ -1,0 +1,72 @@
+package eu.pretix.pretixscan.droid.ui
+
+import android.app.ProgressDialog
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import eu.pretix.libpretixsync.api.PretixApi
+import eu.pretix.pretixscan.droid.AndroidHttpClientFactory
+import eu.pretix.pretixscan.droid.AppConfig
+import eu.pretix.pretixscan.droid.BuildConfig
+import eu.pretix.pretixscan.droid.PretixScan
+import eu.pretix.pretixscan.droid.R
+import eu.pretix.pretixscan.droid.databinding.ActivityLoginBinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+
+class LoginActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityLoginBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_login)
+
+        binding.btnLogin.setOnClickListener {
+            performLogin()
+        }
+    }
+
+    private fun performLogin() {
+        val conf = AppConfig(this)
+        val api = PretixApi.fromConfig(conf, AndroidHttpClientFactory(application as PretixScan))
+        val body = JSONObject().apply {
+            put("hardware_brand", Build.BRAND)
+            put("hardware_model", Build.MODEL)
+            put("os_name", (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) Build.VERSION.BASE_OS else "").ifEmpty { "Android" })
+            put("os_version", Build.VERSION.RELEASE)
+            put("software_brand", "pretixSCAN Android")
+            put("software_version", BuildConfig.VERSION_NAME)
+            put("user", binding.etUser.text.toString())
+            put("password", binding.etPassword.text.toString())
+        }
+
+        val pd = ProgressDialog(this).apply {
+            isIndeterminate = true
+            setMessage(getString(R.string.progress_registering))
+            setCancelable(false)
+            show()
+        }
+
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                api.postResource(api.apiURL("device/user-login"), body)
+                runOnUiThread {
+                    pd.dismiss()
+                    startActivity(Intent(this@LoginActivity, MainActivity::class.java))
+                    finish()
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                runOnUiThread {
+                    pd.dismiss()
+                    Toast.makeText(this@LoginActivity, e.message ?: "Login failed", Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
+}

--- a/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/SetupActivity.kt
+++ b/pretixscan/app/src/main/java/eu/pretix/pretixscan/droid/ui/SetupActivity.kt
@@ -100,7 +100,7 @@ class SetupActivity : AppCompatActivity(R.layout.activity_setup), SetupCallable 
     }
 
     override fun onSuccessfulSetup() {
-        val intent = Intent(this, MainActivity::class.java)
+        val intent = Intent(this, ChooseModeActivity::class.java)
         startActivity(intent)
         finish()
     }

--- a/pretixscan/app/src/main/res/layout/activity_choose_mode.xml
+++ b/pretixscan/app/src/main/res/layout/activity_choose_mode.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="16dp">
+
+        <CheckBox
+            android:id="@+id/cbSignIn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/choose_sign_in"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+        <CheckBox
+            android:id="@+id/cbCheckIn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/choose_check_in"
+            app:layout_constraintTop_toBottomOf="@id/cbSignIn"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginTop="16dp"/>
+
+        <Button
+            android:id="@+id/btnNext"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/cont"
+            app:layout_constraintTop_toBottomOf="@id/cbCheckIn"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginTop="24dp"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/pretixscan/app/src/main/res/layout/activity_login.xml
+++ b/pretixscan/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="16dp">
+
+        <EditText
+            android:id="@+id/etUser"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:hint="@string/login_user_hint"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <EditText
+            android:id="@+id/etPassword"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:hint="@string/login_password_hint"
+            android:inputType="textPassword"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/etUser"
+            android:layout_marginTop="16dp" />
+
+        <Button
+            android:id="@+id/btnLogin"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/login_button"
+            app:layout_constraintTop_toBottomOf="@id/etPassword"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginTop="24dp" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/pretixscan/app/src/main/res/values/strings.xml
+++ b/pretixscan/app/src/main/res/values/strings.xml
@@ -71,6 +71,12 @@
     <string name="welcome_text">pretixSCAN is a event entry app that you can use to validate tickets that you sold through pretix.</string>
     <string name="welcome_disclaimer1">I understand that personal data of attendees of my connected events will be stored on this device and I will secure the device properly.</string>
     <string name="cont">CONTINUE</string>
+    <string name="choose_sign_in">Sign in</string>
+    <string name="choose_check_in">Check in</string>
+    <string name="error_no_option_selected">Please select an option</string>
+    <string name="login_user_hint">Username</string>
+    <string name="login_password_hint">Password</string>
+    <string name="login_button">LOGIN</string>
     <string name="hint_url">URL</string>
     <string name="hint_token">Token</string>
     <string name="dismiss">Dismiss</string>


### PR DESCRIPTION
## Summary
- present a new screen after setup to choose between sign-in and check-in
- implement login flow and call `/v1/device/user-login`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aeda296688323aa024037cb757b03